### PR TITLE
Fix regression report-size-deltas after updating upload-artifact.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -36,6 +36,7 @@ jobs:
           - fqbn: Intel:arc32:arduino_101
             platforms: |
               - name: Intel:arc32
+            artifact-name-suffix: Intel-arc32-arduino_101
 
     steps:
       - name: Checkout repository
@@ -62,4 +63,4 @@ jobs:
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@v1
         with:
-          # The name of the workflow artifact created by the sketch compilation workflow
-          sketches-reports-source: sketches-reports
+          # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+          sketches-reports-source: ^sketches-report-.+


### PR DESCRIPTION
For more information see https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .