### PR TITLE
Allow flexible update intervals

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,7 +13,9 @@ Madgwick	KEYWORD1
 #######################################
 
 update	KEYWORD2
+updateDt	KEYWORD2
 updateIMU	KEYWORD2
+updateIMUDt	KEYWORD2
 getPitch	KEYWORD2
 getYaw	KEYWORD2
 getRoll	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -13,9 +13,7 @@ Madgwick	KEYWORD1
 #######################################
 
 update	KEYWORD2
-updateDt	KEYWORD2
 updateIMU	KEYWORD2
-updateIMUDt	KEYWORD2
 getPitch	KEYWORD2
 getYaw	KEYWORD2
 getRoll	KEYWORD2

--- a/src/MadgwickAHRS.cpp
+++ b/src/MadgwickAHRS.cpp
@@ -21,6 +21,7 @@
 
 #include "MadgwickAHRS.h"
 #include <math.h>
+#include <time.h>
 
 //-------------------------------------------------------------------------------------------
 // Definitions
@@ -41,8 +42,10 @@ Madgwick::Madgwick() {
 	q1 = 0.0f;
 	q2 = 0.0f;
 	q3 = 0.0f;
-	invSampleFreq = 1.0f / sampleFreqDef;
+	invSampleFreq = 0;
 	anglesComputed = 0;
+	last_clock = clock();
+	getDt = &Madgwick::calculateDt;
 }
 
 void Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz, float dt) {
@@ -148,7 +151,7 @@ void Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az
 }
 
 void Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz) {
-	update(gx, gy, gz, ax, ay, az, mx, my, mz, invSampleFreq);
+	update(gx, gy, gz, ax, ay, az, mx, my, mz, (*this.*getDt)());
 }
 
 //-------------------------------------------------------------------------------------------
@@ -229,7 +232,7 @@ void Madgwick::updateIMU(float gx, float gy, float gz, float ax, float ay, float
 }
 
 void Madgwick::updateIMU(float gx, float gy, float gz, float ax, float ay, float az) {
-	updateIMU(gx, gy, gz, ax, ay, az, invSampleFreq);
+	updateIMU(gx, gy, gz, ax, ay, az, (*this.*getDt)());
 }
 
 //-------------------------------------------------------------------------------------------
@@ -257,3 +260,15 @@ void Madgwick::computeAngles()
 	anglesComputed = 1;
 }
 
+float Madgwick::calculateDt()
+{
+	clock_t now = clock();
+	float result = double(now - last_clock) / CLOCKS_PER_SEC;
+	last_clock = now;
+	return result;
+}
+
+float Madgwick::getInvSampleFreq()
+{
+	return invSampleFreq;
+}

--- a/src/MadgwickAHRS.cpp
+++ b/src/MadgwickAHRS.cpp
@@ -45,7 +45,7 @@ Madgwick::Madgwick() {
 	anglesComputed = 0;
 }
 
-void Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz) {
+void Madgwick::updateDt(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz, float dt) {
 	float recipNorm;
 	float s0, s1, s2, s3;
 	float qDot1, qDot2, qDot3, qDot4;
@@ -133,10 +133,10 @@ void Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az
 	}
 
 	// Integrate rate of change of quaternion to yield quaternion
-	q0 += qDot1 * invSampleFreq;
-	q1 += qDot2 * invSampleFreq;
-	q2 += qDot3 * invSampleFreq;
-	q3 += qDot4 * invSampleFreq;
+	q0 += qDot1 * dt;
+	q1 += qDot2 * dt;
+	q2 += qDot3 * dt;
+	q3 += qDot4 * dt;
 
 	// Normalise quaternion
 	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
@@ -147,10 +147,14 @@ void Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az
 	anglesComputed = 0;
 }
 
+void Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz) {
+	updateDt(gx, gy, gz, ax, ay, az, mx, my, mz, invSampleFreq);
+}
+
 //-------------------------------------------------------------------------------------------
 // IMU algorithm update
 
-void Madgwick::updateIMU(float gx, float gy, float gz, float ax, float ay, float az) {
+void Madgwick::updateIMUDt(float gx, float gy, float gz, float ax, float ay, float az, float dt) {
 	float recipNorm;
 	float s0, s1, s2, s3;
 	float qDot1, qDot2, qDot3, qDot4;
@@ -210,10 +214,10 @@ void Madgwick::updateIMU(float gx, float gy, float gz, float ax, float ay, float
 	}
 
 	// Integrate rate of change of quaternion to yield quaternion
-	q0 += qDot1 * invSampleFreq;
-	q1 += qDot2 * invSampleFreq;
-	q2 += qDot3 * invSampleFreq;
-	q3 += qDot4 * invSampleFreq;
+	q0 += qDot1 * dt;
+	q1 += qDot2 * dt;
+	q2 += qDot3 * dt;
+	q3 += qDot4 * dt;
 
 	// Normalise quaternion
 	recipNorm = invSqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
@@ -222,6 +226,10 @@ void Madgwick::updateIMU(float gx, float gy, float gz, float ax, float ay, float
 	q2 *= recipNorm;
 	q3 *= recipNorm;
 	anglesComputed = 0;
+}
+
+void Madgwick::updateIMU(float gx, float gy, float gz, float ax, float ay, float az) {
+	updateIMUDt(gx, gy, gz, ax, ay, az, invSampleFreq);
 }
 
 //-------------------------------------------------------------------------------------------

--- a/src/MadgwickAHRS.cpp
+++ b/src/MadgwickAHRS.cpp
@@ -45,7 +45,7 @@ Madgwick::Madgwick() {
 	anglesComputed = 0;
 }
 
-void Madgwick::updateDt(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz, float dt) {
+void Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz, float dt) {
 	float recipNorm;
 	float s0, s1, s2, s3;
 	float qDot1, qDot2, qDot3, qDot4;
@@ -148,13 +148,13 @@ void Madgwick::updateDt(float gx, float gy, float gz, float ax, float ay, float 
 }
 
 void Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz) {
-	updateDt(gx, gy, gz, ax, ay, az, mx, my, mz, invSampleFreq);
+	update(gx, gy, gz, ax, ay, az, mx, my, mz, invSampleFreq);
 }
 
 //-------------------------------------------------------------------------------------------
 // IMU algorithm update
 
-void Madgwick::updateIMUDt(float gx, float gy, float gz, float ax, float ay, float az, float dt) {
+void Madgwick::updateIMU(float gx, float gy, float gz, float ax, float ay, float az, float dt) {
 	float recipNorm;
 	float s0, s1, s2, s3;
 	float qDot1, qDot2, qDot3, qDot4;
@@ -229,7 +229,7 @@ void Madgwick::updateIMUDt(float gx, float gy, float gz, float ax, float ay, flo
 }
 
 void Madgwick::updateIMU(float gx, float gy, float gz, float ax, float ay, float az) {
-	updateIMUDt(gx, gy, gz, ax, ay, az, invSampleFreq);
+	updateIMU(gx, gy, gz, ax, ay, az, invSampleFreq);
 }
 
 //-------------------------------------------------------------------------------------------

--- a/src/MadgwickAHRS.h
+++ b/src/MadgwickAHRS.h
@@ -40,7 +40,9 @@ private:
 public:
     Madgwick(void);
     void begin(float sampleFrequency) { invSampleFreq = 1.0f / sampleFrequency; }
+    void updateDt(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz, float dt);
     void update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz);
+    void updateIMUDt(float gx, float gy, float gz, float ax, float ay, float az, float dt);
     void updateIMU(float gx, float gy, float gz, float ax, float ay, float az);
     //float getPitch(){return atan2f(2.0f * q2 * q3 - 2.0f * q0 * q1, 2.0f * q0 * q0 + 2.0f * q3 * q3 - 1.0f);};
     //float getRoll(){return -1.0f * asinf(2.0f * q1 * q3 + 2.0f * q0 * q2);};

--- a/src/MadgwickAHRS.h
+++ b/src/MadgwickAHRS.h
@@ -40,9 +40,9 @@ private:
 public:
     Madgwick(void);
     void begin(float sampleFrequency) { invSampleFreq = 1.0f / sampleFrequency; }
-    void updateDt(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz, float dt);
+    void update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz, float dt);
     void update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz);
-    void updateIMUDt(float gx, float gy, float gz, float ax, float ay, float az, float dt);
+    void updateIMU(float gx, float gy, float gz, float ax, float ay, float az, float dt);
     void updateIMU(float gx, float gy, float gz, float ax, float ay, float az);
     //float getPitch(){return atan2f(2.0f * q2 * q3 - 2.0f * q0 * q1, 2.0f * q0 * q0 + 2.0f * q3 * q3 - 1.0f);};
     //float getRoll(){return -1.0f * asinf(2.0f * q1 * q3 + 2.0f * q0 * q2);};

--- a/src/MadgwickAHRS.h
+++ b/src/MadgwickAHRS.h
@@ -17,6 +17,7 @@
 #ifndef MadgwickAHRS_h
 #define MadgwickAHRS_h
 #include <math.h>
+#include <time.h>
 
 //--------------------------------------------------------------------------------------------
 // Variable declaration
@@ -34,12 +35,19 @@ private:
     float yaw;
     char anglesComputed;
     void computeAngles();
+    clock_t last_clock;
+    float (Madgwick::*getDt)();
+    float calculateDt();
+    float getInvSampleFreq();
 
 //-------------------------------------------------------------------------------------------
 // Function declarations
 public:
     Madgwick(void);
-    void begin(float sampleFrequency) { invSampleFreq = 1.0f / sampleFrequency; }
+    void begin(float sampleFrequency) { 
+        invSampleFreq = 1.0f / sampleFrequency;
+        getDt = &Madgwick::getInvSampleFreq;
+    }
     void update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz, float dt);
     void update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz);
     void updateIMU(float gx, float gy, float gz, float ax, float ay, float az, float dt);


### PR DESCRIPTION
Currently, the code generates interval information based on the given `sampleFrequency`. 

However, the actual update interval from the IMU may not precisely match this frequency. Therefore, I have modified the code to allow for a more flexible input of the interval.