### PR TITLE
Correct licensing documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,22 +11,13 @@ This library wraps the official implementation of MadgwickAHRS algorithm to get 
 
 == License ==
 
-Copyright (c) Arduino LLC. All right reserved.
+Copyright (c) Sebastian Madgwick, Arduino LLC
 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3.
 
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-Lesser General Public License for more details.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-
+You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 Implementation of Madgwick's IMU and AHRS algorithms.
 See: http://www.x-io.co.uk/node/8#open_source_ahrs_and_imu_algorithms

--- a/src/MadgwickAHRS.cpp
+++ b/src/MadgwickAHRS.cpp
@@ -5,9 +5,10 @@
 // Implementation of Madgwick's IMU and AHRS algorithms.
 // See: http://www.x-io.co.uk/open-source-imu-and-ahrs-algorithms/
 //
-// From the x-io website "Open-source resources available on this website are
-// provided under the GNU General Public Licence unless an alternative licence
-// is provided in source."
+// From https://web.archive.org/web/20190712041101/http://www.x-io.co.uk/open-source-imu-and-ahrs-algorithms/:
+// "Open-source resources available on this website are provided under the
+// [GNU General Public Licence](https://web.archive.org/web/20190712041101/http://www.gnu.org/licenses/gpl.html)
+// unless an alternative licence is provided in source."
 //
 // Date			Author          Notes
 // 29/09/2011	SOH Madgwick    Initial release

--- a/src/MadgwickAHRS.h
+++ b/src/MadgwickAHRS.h
@@ -5,9 +5,10 @@
 // Implementation of Madgwick's IMU and AHRS algorithms.
 // See: http://www.x-io.co.uk/open-source-imu-and-ahrs-algorithms/
 //
-// From the x-io website "Open-source resources available on this website are
-// provided under the GNU General Public Licence unless an alternative licence
-// is provided in source."
+// From https://web.archive.org/web/20190712041101/http://www.x-io.co.uk/open-source-imu-and-ahrs-algorithms/:
+// "Open-source resources available on this website are provided under the
+// [GNU General Public Licence](https://web.archive.org/web/20190712041101/http://www.gnu.org/licenses/gpl.html)
+// unless an alternative licence is provided in source."
 //
 // Date			Author          Notes
 // 29/09/2011	SOH Madgwick    Initial release


### PR DESCRIPTION
The project's readme contains a "License" section which summarizes the project licensing.

Previously the information was incorrect (it seems to just be a copy/paste of the content that was present in most of Arduino's libraries at that time, by someone who didn't actually verify that it was appropriate):

* The copyright assignment for Sebastian Madgwick, the author of the code upon which the library is based was omitted, falsely indicating that Arduino LLC is the sole copyright holder.
* It stated that the project is licensed as LGPL 2.1, when it is actually [the GPL 3.0 licensing inherited from the base code](https://web.archive.org/web/20190712041101/http://www.x-io.co.uk/open-source-imu-and-ahrs-algorithms/#:~:text=Open%2Dsource%20resources%20available%20on%20this%20website%20are%20provided%20under%20the%20GNU%20General%20Public%20Licence).

The missing copyright assignment is hereby added and the license information corrected.

The text of the license summary is the standard license header for the project's GPL 3.0 license:

https://spdx.org/licenses/GPL-3.0-only.html#licenseHeader